### PR TITLE
make the package consumable from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.json"
+    "build": "tsc --project tsconfig.json",
+    "prepare": "npm run build"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
In case you are wondering how "make the package consumable from git" has anything to do with the change. It's because when `npm` installs something from a git repo, it looks for and runs the `prepare` script. Note before `prepare` runs, `npm` also installs dev dependencies so that any builds step may work. This is useful so that the build output will be included in the final installation in a project's node_modules.